### PR TITLE
caching of github stars

### DIFF
--- a/_includes/project.html
+++ b/_includes/project.html
@@ -1,4 +1,4 @@
-g<div class="col-md-6">
+<div class="col-md-6">
   <div class="row">
     <div class="col-md-12">
       <h2>
@@ -32,7 +32,7 @@ g<div class="col-md-6">
             let github_stars = "https://api.github.com/repos/{{ include.project.author }}/{{ include.project.repo_title }}/stargazers";
             if (localStorage.getItem(title)) {
               var count = localStorage.getItem(title);
-              $(title).text(response.length);
+              $(title).text(count);
             } else {
               $.getJSON(github_stars, function (response) {
                   $(title).text(response.length);

--- a/_includes/project.html
+++ b/_includes/project.html
@@ -28,10 +28,8 @@ g<div class="col-md-6">
         ></span>
         <script>
           $(function () {
-ithub
             let title = "#{{ include.project.repo_title }}_count";
-            let github_stars = "https://api.github.com/repos/{{ include.project.author }}/{{ include.project.repo_title }}/stargazers"
-
+            let github_stars = "https://api.github.com/repos/{{ include.project.author }}/{{ include.project.repo_title }}/stargazers";
             if (localStorage.getItem(title)) {
               var count = localStorage.getItem(title);
               $(title).text(response.length);
@@ -39,8 +37,7 @@ ithub
               $.getJSON(github_stars, function (response) {
                   $(title).text(response.length);
                   localStorage.setItem(title, response.length);
-                }
-              );
+                });
             }
           });
         </script>

--- a/_includes/project.html
+++ b/_includes/project.html
@@ -1,4 +1,4 @@
-<div class="col-md-6">
+g<div class="col-md-6">
   <div class="row">
     <div class="col-md-12">
       <h2>
@@ -28,14 +28,20 @@
         ></span>
         <script>
           $(function () {
-            $.getJSON(
-              "https://api.github.com/repos/{{ include.project.author }}/{{ include.project.repo_title }}/stargazers",
-              function (response) {
-                $("#{{ include.project.repo_title }}_count").text(
-                  response.length
-                );
-              }
-            );
+ithub
+            let title = "#{{ include.project.repo_title }}_count";
+            let github_stars = "https://api.github.com/repos/{{ include.project.author }}/{{ include.project.repo_title }}/stargazers"
+
+            if (localStorage.getItem(title)) {
+              var count = localStorage.getItem(title);
+              $(title).text(response.length);
+            } else {
+              $.getJSON(github_stars, function (response) {
+                  $(title).text(response.length);
+                  localStorage.setItem(title, response.length);
+                }
+              );
+            }
           });
         </script>
       </a>


### PR DESCRIPTION
Having an issue where Github would start to block API requests to get the stargazer counts if a page refresh occurred. This now's saves the star count in local storage instead of requesting from github each time